### PR TITLE
Fix boost broken issue with cuda compile

### DIFF
--- a/common/global_configs.h
+++ b/common/global_configs.h
@@ -38,3 +38,8 @@
 
 //Use dense image density term in the solver
 //#define USE_DENSE_IMAGE_DENSITY_TERM
+
+//Fix boost broken issue with cuda compile
+#ifdef __CUDACC__
+#define BOOST_PP_VARIADICS 0
+#endif


### PR DESCRIPTION
According to https://github.com/boostorg/preprocessor/issues/15#issuecomment-401554287
Tested with boost 1.68.0 with vs2015, cuda 9.0, win10