### PR TITLE
Update to support modern cilantro

### DIFF
--- a/common/point_cloud_typedefs.h
+++ b/common/point_cloud_typedefs.h
@@ -10,7 +10,7 @@ typedef pcl::PointCloud<pcl::PointXYZ>::Ptr    PointCloud3f_Pointer;
 typedef pcl::PointCloud<pcl::Normal>::Ptr      PointCloudNormal_Pointer;
 typedef pcl::PointCloud<pcl::PointXYZRGB>::Ptr PointCloud3fRGB_Pointer;
 #elif defined(WITH_CILANTRO)
-#include <cilantro/point_cloud.hpp>
+#include <cilantro/utilities/point_cloud.hpp>
 typedef cilantro::PointCloud3f PointCloud3f;
 typedef cilantro::PointCloud3f PointCloudNormal;
 typedef cilantro::PointCloud3f PointCloud3fRGB;

--- a/visualization/PointCloudVisualizer.cpp
+++ b/visualization/PointCloudVisualizer.cpp
@@ -14,8 +14,8 @@
 #include <pcl/visualization/pcl_visualizer.h>
 #elif defined(WITH_CILANTRO)
 
-#include <cilantro/visualizer.hpp>
-#include <cilantro/common_renderables.hpp>
+#include <cilantro/visualization/visualizer.hpp>
+#include <cilantro/visualization/common_renderables.hpp>
 
 #endif
 


### PR DESCRIPTION
Some of the headers moved.  These edits respect cilantro commit `db1268f3d223cf6a74cb17489aa54bb8a50073b1`